### PR TITLE
fix versioning of exapowerio

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,13 +13,12 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [sources]
-ExaPowerIO = {rev = "003970f", url = "https://github.com/MadNLP/ExaPowerIO.jl"}
 GOC3Benchmark = {rev = "588f356", url = "https://github.com/lanl-ansi/GOC3Benchmark.jl"}
 
 [compat]
 CUDA = "5 - 5.8.2"
 ExaModels = "0.9.1"
-ExaPowerIO = "0.2.0"
+ExaPowerIO = "^0.2.1"
 JLD2 = "~0.5"
 MadNLP = "~0.8"
 MadNLPGPU = "~0.7"


### PR DESCRIPTION
Uses the new version of ExaPowerIO: https://github.com/JuliaRegistries/General/pull/138799