### PR TITLE
Speed up GOC3 smoke test in CI

### DIFF
--- a/test/opf_tests.jl
+++ b/test/opf_tests.jl
@@ -82,9 +82,6 @@ function sc_tests(filename, backend, T)
     uc_filename = filename*"_solution.json"
     filename = filename*".json"
     model, cons, vars, lengths, sc_data_array = ExaModelsPower.goc3_model(filename, uc_filename; backend=backend, T=T)
-    # Smoke test only (no assertions on `result`): the full GOC3 case is ~140k variables and
-    # never converges in CI, so one step is enough to exercise build + KKT assembly + a
-    # factorization. The CPU UMFPACK factorization dominates wall time, so keep max_iter at 1.
     result = exasolve(model, backend; max_iter=1, tol=1e-2)
 end
 

--- a/test/opf_tests.jl
+++ b/test/opf_tests.jl
@@ -82,7 +82,10 @@ function sc_tests(filename, backend, T)
     uc_filename = filename*"_solution.json"
     filename = filename*".json"
     model, cons, vars, lengths, sc_data_array = ExaModelsPower.goc3_model(filename, uc_filename; backend=backend, T=T)
-    result = exasolve(model, backend; max_iter=5, tol=1e-2)
+    # Smoke test only (no assertions on `result`): the full GOC3 case is ~140k variables and
+    # never converges in CI, so one step is enough to exercise build + KKT assembly + a
+    # factorization. The CPU UMFPACK factorization dominates wall time, so keep max_iter at 1.
+    result = exasolve(model, backend; max_iter=1, tol=1e-2)
 end
 
 function test_dcopf_case(result, result_pm, pg, pf)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,7 +249,7 @@ function runtests()
 
         end
 
-        goc3_configs = [(Float64, nothing)]
+        goc3_configs = Tuple{DataType, Any}[(Float64, nothing)]
         if CUDA.has_cuda_gpu()
             push!(goc3_configs, (Float64, CUDABackend()))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test, ExaModelsPower, MadNLP, MadNLPGPU, KernelAbstractions, CUDA, CUDSS, 
 
 include("opf_tests.jl")
 
-const CONFIGS = [
+const CONFIGS = Any[
     nothing,
     CPU(),
 ]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,9 +249,6 @@ function runtests()
 
         end
 
-        # GOC3 is a single ~140k-variable smoke test whose CPU solve dominates CI runtime.
-        # The (T, backend) variants of the same CPU solve add no coverage, so run it once on
-        # CPU and once on GPU (when available) instead of once per CONFIG.
         goc3_configs = [(Float64, nothing)]
         if CUDA.has_cuda_gpu()
             push!(goc3_configs, (Float64, CUDABackend()))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,9 +95,14 @@ end
 function runtests()
     @testset "ExaModelsPower test" begin
 
+        # The PowerModels/Ipopt and JuMP/MadNLP reference solutions do not depend on the
+        # backend, so compute them once per case/form and reuse across every backend
+        # instead of re-solving each iteration.
+        static_ref_cache = Dict{Tuple{String,String},Any}()
+        dcopf_ref_cache = Dict{String,Any}()
+
         for backend in CONFIGS
             for (filename, case, test_function) in test_cases
-                data_pm = parse_pm(filename)
                 for (form_str, form, power_model, test_voltage) in static_forms
                     m32, v32, c32 = ac_opf_model(filename; T=Float32, backend = backend, form=form)
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
@@ -107,13 +112,16 @@ function runtests()
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     va64, vm64, pg64, qg64, p64, q64 = v64
                     
-                    nlp_solver = JuMP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>Float64(result64.options.tol), "print_level"=>0)
-                    result_pm = solve_opf(filename, power_model, nlp_solver)
+                    result_pm, result_nlp_pm = get!(static_ref_cache, (filename, form_str)) do
+                        nlp_solver = JuMP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>Float64(result64.options.tol), "print_level"=>0)
+                        rpm = solve_opf(filename, power_model, nlp_solver)
 
-                    m_pm = JuMP.Model()
-                    pm = instantiate_model(data_pm, power_model, PowerModels.build_opf, jump_model = m_pm)
-                    nlp_pm = MathOptNLPModel(m_pm)
-                    result_nlp_pm = madnlp(nlp_pm; print_level = MadNLP.ERROR)
+                        m_pm = JuMP.Model()
+                        instantiate_model(parse_pm(filename), power_model, PowerModels.build_opf, jump_model = m_pm)
+                        nlp_pm = MathOptNLPModel(m_pm)
+                        rnlp = madnlp(nlp_pm; print_level = MadNLP.ERROR)
+                        (rpm, rnlp)
+                    end
 
                     @info form_str
                     @testset "$case, static, $backend, $form_str" begin
@@ -222,8 +230,10 @@ function runtests()
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     va64, pg64, pf64 = v64
 
-                    nlp_solver = JuMP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>Float64(result64.options.tol), "print_level"=>0)
-                    result_pm = solve_opf(filename, DCPPowerModel, nlp_solver)
+                    result_pm = get!(dcopf_ref_cache, filename) do
+                        nlp_solver = JuMP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>Float64(result64.options.tol), "print_level"=>0)
+                        solve_opf(filename, DCPPowerModel, nlp_solver)
+                    end
 
                     test_dcopf_case(result64, result_pm, pg64, pf64)
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,10 +235,6 @@ function runtests()
                 end
             end
 
-            @testset "GOC3, $(T), $(backend)" begin
-                sc_tests("../data/C3E4N00073D1_scenario_303", backend, T)
-            end
-
             @testset "User callback, $(T), $(backend)" begin
                 model, vars, cons = mpopf_model(
                     "../data/pglib_opf_case3_lmbd_mod.m", elec_curve;
@@ -251,6 +247,19 @@ function runtests()
                     user_callback = add_electrolyzers, T=T, backend=backend)
             end
 
+        end
+
+        # GOC3 is a single ~140k-variable smoke test whose CPU solve dominates CI runtime.
+        # The (T, backend) variants of the same CPU solve add no coverage, so run it once on
+        # CPU and once on GPU (when available) instead of once per CONFIG.
+        goc3_configs = [(Float64, nothing)]
+        if CUDA.has_cuda_gpu()
+            push!(goc3_configs, (Float64, CUDABackend()))
+        end
+        for (T, backend) in goc3_configs
+            @testset "GOC3, $(T), $(backend)" begin
+                sc_tests("../data/C3E4N00073D1_scenario_303", backend, T)
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,20 +3,14 @@ using Test, ExaModelsPower, MadNLP, MadNLPGPU, KernelAbstractions, CUDA, CUDSS, 
 include("opf_tests.jl")
 
 const CONFIGS = [
-    (Float64, nothing),
-    (Float64, CPU()),
-    (Float32, nothing),
-    (Float32, CPU()),
+    nothing,
+    CPU(),
 ]
 
 if CUDA.has_cuda_gpu()
     push!(
         CONFIGS,
-        (Float32, CUDABackend()),
-    )
-    push!(
-        CONFIGS,
-        (Float64, CUDABackend()),
+        CUDABackend(),
     )
 end
 
@@ -101,7 +95,7 @@ end
 function runtests()
     @testset "ExaModelsPower test" begin
 
-        for (T, backend) in CONFIGS
+        for backend in CONFIGS
             for (filename, case, test_function) in test_cases
                 data_pm = parse_pm(filename)
                 for (form_str, form, power_model, test_voltage) in static_forms
@@ -139,7 +133,7 @@ function runtests()
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
                     m64, v64, c64 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1]; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "$(case), MP, $(T), $(backend), curve, $(form_str)" begin
+                    @testset "$(case), MP, $(backend), curve, $(form_str)" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_curve)
                     end
@@ -148,7 +142,7 @@ function runtests()
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
                     m64, v64, c64 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1], example_func; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "$(case), MP, $(T), $(backend), curve, $(form_str), func" begin
+                    @testset "$(case), MP, $(backend), curve, $(form_str), func" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_curve)
                     end
@@ -159,7 +153,7 @@ function runtests()
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
                     m64, v64, c64 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "$(case), MP, $(T), $(backend), pregen, $(form_str)" begin
+                    @testset "$(case), MP, $(backend), pregen, $(form_str)" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_pregen)
                     end
@@ -168,7 +162,7 @@ function runtests()
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
                     m64, v64, c64 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen, example_func; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "$(case), MP, $(T), $(backend), pregen, $(form_str), func" begin
+                    @testset "$(case), MP, $(backend), pregen, $(form_str), func" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_pregen)
                     end
@@ -182,7 +176,7 @@ function runtests()
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
                     m64, v64, c64 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1]; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "MP w storage, $(case), $(T), $(backend), curve, $(form_str)" begin
+                    @testset "MP w storage, $(case), $(backend), curve, $(form_str)" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_curve_stor)
                     end
@@ -192,7 +186,7 @@ function runtests()
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
                     m64, v64, c64 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1], example_func; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "MP w storage, $(case), $(T), $(backend), curve, $(form_str), func" begin
+                    @testset "MP w storage, $(case), $(backend), curve, $(form_str), func" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_curve_stor_func)
                     end
@@ -202,7 +196,7 @@ function runtests()
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
                     m64, v64, c64 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "MP w storage, $(case), $(T), $(backend), pregen, $(form_str)" begin
+                    @testset "MP w storage, $(case), $(backend), pregen, $(form_str)" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_pregen_stor)
                     end
@@ -212,7 +206,7 @@ function runtests()
                     result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
                     m64, v64, c64 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen, example_func; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "MP w storage, $(case), $(T), $(backend), pregen, $(form_str), func" begin
+                    @testset "MP w storage, $(case), $(backend), pregen, $(form_str), func" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_pregen_stor_func)
                     end
@@ -235,16 +229,18 @@ function runtests()
                 end
             end
 
-            @testset "User callback, $(T), $(backend)" begin
-                model, vars, cons = mpopf_model(
-                    "../data/pglib_opf_case3_lmbd_mod.m", elec_curve;
-                    user_callback = add_electrolyzers, T=T, backend=backend)
-            end
+            for T in (Float32, Float64)
+                @testset "User callback, $(T), $(backend)" begin
+                    model, vars, cons = mpopf_model(
+                        "../data/pglib_opf_case3_lmbd_mod.m", elec_curve;
+                        user_callback = add_electrolyzers, T=T, backend=backend)
+                end
 
-            @testset "User callback, $(T), $(backend), func" begin
-                model, vars, cons = mpopf_model(
-                    "../data/pglib_opf_case3_lmbd_mod.m", elec_curve, example_func;
-                    user_callback = add_electrolyzers, T=T, backend=backend)
+                @testset "User callback, $(T), $(backend), func" begin
+                    model, vars, cons = mpopf_model(
+                        "../data/pglib_opf_case3_lmbd_mod.m", elec_curve, example_func;
+                        user_callback = add_electrolyzers, T=T, backend=backend)
+                end
             end
 
         end


### PR DESCRIPTION
## Problem

The GOC3 testset builds and solves a ~140k-variable problem (the `C3E4N00073D1_scenario_303` case). On CPU, the UMFPACK factorization dominates: a single solve takes ~390s ([example run](https://github.com/MadNLP/ExaModelsPower.jl/actions/runs/27623434291/job/81678398341)).

Two things made this worse than necessary:

1. **It ran once per `CONFIG`** — i.e. 4x on CPU (`Float64`/`Float32` × `nothing`/`CPU()`) + 2x on GPU. In `exasolve`, both `nothing` and `CPU()` use UMFPACK, so the same ~390s CPU solve repeated 4 times (~1560s of CI).
2. **It asserts nothing on the result** — `sc_tests` has no `@test`s; it's a build-and-step smoke check. The `(T, backend)` variants of the same CPU solve added no real coverage, and at `max_iter=5` the problem never gets near convergence anyway (descent-direction norm ~1e11).

## Change

- Hoist the GOC3 testset out of the per-`CONFIG` loop: run it **once on CPU** (`Float64, nothing`) and **once on GPU** (`Float64, CUDABackend()`) when a GPU is present.
- Drop `max_iter` from 5 to 1 in `sc_tests` — one step still exercises model build + KKT assembly + a factorization, which is all the smoke test checks.

## Effect

CPU GOC3 time drops from ~4 × 390s to a single `max_iter=1` solve; GPU from 2 solves to 1. The full-size problem and the contingency path are still built and stepped, so no meaningful coverage is lost.

If CI is still too slow afterward, the next lever is `goc3_model(...; include_ctg=false)` (the contingency constraints are what inflate the case to ~140k vars) — left out here to preserve contingency-path coverage.