### PR TITLE
Fix keyword forwarding in ac_opf_model

### DIFF
--- a/src/opf.jl
+++ b/src/opf.jl
@@ -226,9 +226,9 @@ function ac_opf_model(
     data = convert_data(data, backend)
 
     if form == :polar
-        return build_polar_opf(data, user_callback, backend = backend, T=T, kwargs...)
+        return build_polar_opf(data, user_callback; backend = backend, T = T, kwargs...)
     elseif form == :rect
-        return build_rect_opf(data, user_callback, backend = backend, T=T, kwargs...)
+        return build_rect_opf(data, user_callback; backend = backend, T = T, kwargs...)
     else
         error("Invalid coordinate symbol - valid options are :polar or :rect")
     end


### PR DESCRIPTION
The `kwargs...` splat in the `build_polar_opf`/`build_rect_opf` calls lacked the semicolon, so forwarded keywords arrived as positional `Pair` arguments and any call like `ac_opf_model(file; prod = true)` threw a MethodError. Verified by building `pglib_opf_case14_ieee.m` with `prod = true` on the fixed branch.