### PR TITLE
Split CI into per-backend jobs and cut redundant test work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,28 @@ permissions:
   actions: write
   contents: read
 
+# A test run takes over two hours on the self-hosted GPU runners, so a second push to a
+# pull request otherwise leaves two full runs of the same branch competing for the pool.
+# Superseded pull-request runs are cancelled; runs on main are left alone so that every
+# merged commit still reports coverage.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
+    name: test (${{ matrix.selection }})
     runs-on:
       labels: cuda13
     strategy:
+      # One slice failing should not cancel the others; they are independent, and GOC3 is
+      # much the longest, so cancelling it on an unrelated backend failure wastes the run.
+      fail-fast: false
       matrix:
         julia-version: ['1']
+        # Each backend, and the GOC3 smoke test, run as their own job so that the wall
+        # clock is the slowest slice rather than the sum of all of them.
+        selection: ['nothing', 'cpu', 'cuda', 'goc3']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,6 +41,8 @@ jobs:
           channel: ${{ matrix.julia-version }}
       - name: Run tests
         shell: julia --project=. --color=yes {0}
+        env:
+          EMP_TEST_SELECTION: ${{ matrix.selection }}
         run: |
           using Pkg;
           Pkg.Registry.update()
@@ -36,4 +53,7 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
+          # Each slice covers a different part of src; flag them so Codecov merges the
+          # four partial reports for a commit instead of treating them as replacements.
+          flags: ${{ matrix.selection }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,12 @@ on:
     tags: '*'
   pull_request:
 
+# The docs build shares the self-hosted GPU runners with CI, so drop superseded
+# pull-request builds instead of queueing them behind the test job.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on:

--- a/test/opf_tests.jl
+++ b/test/opf_tests.jl
@@ -54,17 +54,26 @@ function test_case14(result, result_pm, result_nlp_pm, pg, qg, p, q)
     test_static_case(result, result_pm, result_nlp_pm, pg, qg)
 end
 
-function test_float32(m, m64, result, backend)
-    x1 = result.solution
-    tol = 2.71828^(log(result.options.tol)/2)
+# Every configuration is checked by evaluating the model callbacks -- objective,
+# constraints, gradient and Jacobian -- and comparing the Float32 model against the
+# Float64 one.  The evaluation point is the model's own initial point rather than a
+# solution, so this needs no solve, which is what makes it cheap enough to run over the
+# whole cross-product.
+function test_callbacks(m32, m64, backend)
+    x1 = m64.meta.x0
+    tol = 1e-4
     x2 = x1 .* (1 .+ 0.01 .* (2 .* rand(size(x1)) .- 1))
     x3 = x1 .* (1 .+ 0.01 .* (2 .* rand(size(x1)) .- 1))
     for x in [x1, x2, x3]
-        @test isapprox(NLPModelsJuMP.obj(m, x), NLPModelsJuMP.obj(m64, x), rtol = tol)
-        @test isapprox(NLPModelsJuMP.cons(m, x), NLPModelsJuMP.cons(m64, x), rtol = tol)
+        o64 = NLPModelsJuMP.obj(m64, x)
+        @test isfinite(o64)
+        @test isapprox(NLPModelsJuMP.obj(m32, x), o64, rtol = tol)
+        c64 = NLPModelsJuMP.cons(m64, x)
+        @test all(isfinite, Array(c64))
+        @test isapprox(NLPModelsJuMP.cons(m32, x), c64, rtol = tol)
         if backend != CUDABackend()
-            @test isapprox(NLPModelsJuMP.grad(m, x), NLPModelsJuMP.grad(m64, x), rtol = tol)
-            @test isapprox(NLPModelsJuMP.jac(m, x), NLPModelsJuMP.jac(m64, x), rtol = tol)
+            @test isapprox(NLPModelsJuMP.grad(m32, x), NLPModelsJuMP.grad(m64, x), rtol = tol)
+            @test isapprox(NLPModelsJuMP.jac(m32, x), NLPModelsJuMP.jac(m64, x), rtol = tol)
         end
     end
 end
@@ -74,11 +83,16 @@ function test_mp_case(result, true_sol)
     @test isapprox(result.objective, true_sol, rtol = result.options.tol*100)
 end
 
+# GOC3 is a smoke test of the parser and the model constructor.  Solving it cost 32 of the
+# 47 min this section took in CI, for one iteration of a 139502-variable problem, so build
+# the model and evaluate its callbacks instead of solving.
 function sc_tests(filename, backend, T)
     uc_filename = filename*"_solution.json"
     filename = filename*".json"
     model, cons, vars, lengths, sc_data_array = ExaModelsPower.goc3_model(filename, uc_filename; backend=backend, T=T)
-    result = exasolve(model, backend; max_iter=1, tol=1e-2)
+    x0 = model.meta.x0
+    @test isfinite(NLPModelsJuMP.obj(model, x0))
+    @test all(isfinite, Array(NLPModelsJuMP.cons(model, x0)))
 end
 
 function test_dcopf_case(result, result_pm, pg, pf)

--- a/test/opf_tests.jl
+++ b/test/opf_tests.jl
@@ -33,8 +33,6 @@ function test_static_case(result, result_pm, result_nlp_pm, pg, qg)
 end
 
 function test_polar_voltage(result, result_pm, va, vm)
-    @info "ppolar"
-    @info result_pm
     for i in 1:length(result_pm["solution"]["bus"])
         @test isapprox(Array(solution(result, va))[i], result_pm["solution"]["bus"][string(i)]["va"], atol = result.options.tol*100)
         @test isapprox(Array(solution(result, vm))[i], result_pm["solution"]["bus"][string(i)]["vm"], rtol = result.options.tol*100)
@@ -42,8 +40,6 @@ function test_polar_voltage(result, result_pm, va, vm)
 end
 
 function test_rect_voltage(result, result_pm, vr, vim)
-    @info "rrect"
-    @info result_pm
     for i in 1:length(result_pm["solution"]["bus"])
         @test isapprox(Array(solution(result, vr))[i], result_pm["solution"]["bus"][string(i)]["vr"], rtol = result.options.tol*100)
         @test isapprox(Array(solution(result, vim))[i], result_pm["solution"]["bus"][string(i)]["vi"], atol = result.options.tol*100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,146 +107,120 @@ end
 function runtests()
     @testset "ExaModelsPower test" begin
 
-        # The PowerModels/Ipopt and JuMP/MadNLP reference solutions do not depend on the
-        # backend, so compute them once per case/form and reuse across every backend
-        # instead of re-solving each iteration.
-        static_ref_cache = Dict{Tuple{String,String},Any}()
-        dcopf_ref_cache = Dict{String,Any}()
+        # Solving is the expensive half of this suite, and MadNLP is not what this package
+        # is responsible for: its job is to build correct models.  So the smallest case is
+        # solved once on the CPU and once on the GPU -- static AC against the
+        # PowerModels/Ipopt reference, and multi-period against the hardcoded objective --
+        # and every other configuration is checked by evaluating its callbacks.
+        solve_here(backend) = backend === nothing || backend isa CUDABackend
+        solve_case, solve_form = "case3", "rect"
 
-        # The multi-period sections dominated the OPF phase (33.5 of its 49.4 min) and
+        # The PowerModels/Ipopt and JuMP/MadNLP reference solutions do not depend on the
+        # backend, so compute them once per case/form and reuse them.
+        static_ref_cache = Dict{Tuple{String,String},Any}()
+
         # case3 and case5 exercise the same code with different data, so the multi-period
-        # sections keep case3 only.  Every backend otherwise runs the same set: with one
-        # job per backend the wall clock is the slowest backend, not their sum, so there
-        # is nothing to gain by giving them different coverage.
+        # sections keep case3 only.  Every backend runs the same set: with one job per
+        # backend the wall clock is the slowest backend, not the sum of all of them.
         mp_cases = mp_test_cases[1:1]
         mp_stor  = mp_stor_test_cases[1:1]
 
         for backend in CONFIGS
+            solving = solve_here(backend)
+
+            # Static AC
             for (filename, case, test_function) in test_cases
                 for (form_str, form, power_model, test_voltage) in static_forms
                     m32, _, _ = ac_opf_model(filename; T=Float32, backend = backend, form=form)
-
-                    m64, v64, c64 = ac_opf_model(filename; T=Float64, backend = backend, form=form)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    va64, vm64, pg64, qg64, p64, q64 = v64
-                    
-                    result_pm, result_nlp_pm = get!(static_ref_cache, (filename, form_str)) do
-                        nlp_solver = JuMP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>Float64(result64.options.tol), "print_level"=>0)
-                        rpm = solve_opf(filename, power_model, nlp_solver)
-
-                        m_pm = JuMP.Model()
-                        instantiate_model(parse_pm(filename), power_model, PowerModels.build_opf, jump_model = m_pm)
-                        nlp_pm = MathOptNLPModel(m_pm)
-                        rnlp = madnlp(nlp_pm; print_level = MadNLP.ERROR)
-                        (rpm, rnlp)
-                    end
+                    m64, v64, _ = ac_opf_model(filename; T=Float64, backend = backend, form=form)
 
                     @testset "$case, static, $backend, $form_str" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_function(result64, result_pm, result_nlp_pm, pg64, qg64, p64, q64)
-                        test_voltage(result64, result_pm, va64, vm64)
+                        test_callbacks(m32, m64, backend)
+                    end
+
+                    if solving && case == solve_case && form_str == solve_form
+                        va64, vm64, pg64, qg64, p64, q64 = v64
+                        result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
+
+                        result_pm, result_nlp_pm = get!(static_ref_cache, (filename, form_str)) do
+                            nlp_solver = JuMP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>Float64(result64.options.tol), "print_level"=>0)
+                            rpm = solve_opf(filename, power_model, nlp_solver)
+
+                            m_pm = JuMP.Model()
+                            instantiate_model(parse_pm(filename), power_model, PowerModels.build_opf, jump_model = m_pm)
+                            rnlp = madnlp(MathOptNLPModel(m_pm); print_level = MadNLP.ERROR)
+                            (rpm, rnlp)
+                        end
+
+                        @testset "$case, static solve, $backend, $form_str" begin
+                            test_function(result64, result_pm, result_nlp_pm, pg64, qg64, p64, q64)
+                            test_voltage(result64, result_pm, va64, vm64)
+                        end
                     end
                 end
             end
-            
-            #Test MP
+
+            # Multi-period
             for (form_str, symbol) in mp_forms
                 for (filename, case, Pd_pregen, Qd_pregen, true_sol_curve, true_sol_pregen) in mp_cases
-                    #Curve = [1, .9, .8, .95, 1]
+                    variants = [
+                        ("curve",        () -> (T -> mpopf_model(filename, [1, .9, .8, .95, 1]; T = T, backend = backend, form = symbol))),
+                        ("curve, func",  () -> (T -> mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = T, backend = backend, form = symbol))),
+                        ("pregen",       () -> (T -> mpopf_model(filename, Pd_pregen, Qd_pregen; T = T, backend = backend, form = symbol))),
+                        ("pregen, func", () -> (T -> mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = T, backend = backend, form = symbol))),
+                    ]
+                    for (label, mk) in variants
+                        build = mk()
+                        m32, _, _ = build(Float32)
+                        m64, _, _ = build(Float64)
 
-                    m32, _, _ = mpopf_model(filename, [1, .9, .8, .95, 1]; T = Float32, backend = backend, form = symbol)
-                    m64, v64, c64 = mpopf_model(filename, [1, .9, .8, .95, 1]; T = Float64, backend = backend, form = symbol)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "$(case), MP, $(backend), curve, $(form_str)" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_mp_case(result64, true_sol_curve)
-                    end
-                    #w function
-                    m32, _, _ = mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = Float32, backend = backend, form = symbol)
-                    m64, v64, c64 = mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = Float64, backend = backend, form = symbol)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "$(case), MP, $(backend), curve, $(form_str), func" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_mp_case(result64, true_sol_curve)
-                    end
-                
+                        @testset "$(case), MP, $(backend), $(label), $(form_str)" begin
+                            test_callbacks(m32, m64, backend)
+                        end
 
-                    #Pregenerated Pd and Qd
-                    m32, _, _ = mpopf_model(filename, Pd_pregen, Qd_pregen; T = Float32, backend = backend, form = symbol)
-                    m64, v64, c64 = mpopf_model(filename, Pd_pregen, Qd_pregen; T = Float64, backend = backend, form = symbol)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "$(case), MP, $(backend), pregen, $(form_str)" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_mp_case(result64, true_sol_pregen)
-                    end
-                    #w function
-                    m32, _, _ = mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = Float32, backend = backend, form = symbol)
-                    m64, v64, c64 = mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = Float64, backend = backend, form = symbol)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "$(case), MP, $(backend), pregen, $(form_str), func" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_mp_case(result64, true_sol_pregen)
+                        # The one solve kept for the objective regression: the hardcoded
+                        # multi-period solutions are the only check on mpopf answers.
+                        if solving && case == solve_case && form_str == solve_form && label == "curve"
+                            result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
+                            @testset "$(case), MP solve, $(backend), $(label), $(form_str)" begin
+                                test_mp_case(result64, true_sol_curve)
+                            end
+                        end
                     end
                 end
-                
-                # Test MP w storage
-                for (filename, case, Pd_pregen, Qd_pregen, true_sol_curve_stor, 
+
+                # Multi-period with storage
+                for (filename, case, Pd_pregen, Qd_pregen, true_sol_curve_stor,
                     true_sol_curve_stor_func, true_sol_pregen_stor, true_sol_pregen_stor_func) in mp_stor
-                    
-                    m32, _, _ = mpopf_model(filename, [1, .9, .8, .95, 1]; T = Float32, backend = backend, form = symbol)
-                    m64, v64, c64 = mpopf_model(filename, [1, .9, .8, .95, 1]; T = Float64, backend = backend, form = symbol)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "MP w storage, $(case), $(backend), curve, $(form_str)" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_mp_case(result64, true_sol_curve_stor)
-                    end
 
-                    #With function
-                    m32, _, _ = mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = Float32, backend = backend, form = symbol)
-                    m64, v64, c64 = mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = Float64, backend = backend, form = symbol)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "MP w storage, $(case), $(backend), curve, $(form_str), func" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_mp_case(result64, true_sol_curve_stor_func)
-                    end
+                    variants = [
+                        ("curve",        () -> (T -> mpopf_model(filename, [1, .9, .8, .95, 1]; T = T, backend = backend, form = symbol))),
+                        ("curve, func",  () -> (T -> mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = T, backend = backend, form = symbol))),
+                        ("pregen",       () -> (T -> mpopf_model(filename, Pd_pregen, Qd_pregen; T = T, backend = backend, form = symbol))),
+                        ("pregen, func", () -> (T -> mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = T, backend = backend, form = symbol))),
+                    ]
+                    for (label, mk) in variants
+                        build = mk()
+                        m32, _, _ = build(Float32)
+                        m64, _, _ = build(Float64)
 
-                    #Pregenerated Pd and Qd
-                    m32, _, _ = mpopf_model(filename, Pd_pregen, Qd_pregen; T = Float32, backend = backend, form = symbol)
-                    m64, v64, c64 = mpopf_model(filename, Pd_pregen, Qd_pregen; T = Float64, backend = backend, form = symbol)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "MP w storage, $(case), $(backend), pregen, $(form_str)" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_mp_case(result64, true_sol_pregen_stor)
-                    end
-
-                    #With function
-                    m32, _, _ = mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = Float32, backend = backend, form = symbol)
-                    m64, v64, c64 = mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = Float64, backend = backend, form = symbol)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    @testset "MP w storage, $(case), $(backend), pregen, $(form_str), func" begin
-                        test_float32(m32, m64, result64, backend)
-                        test_mp_case(result64, true_sol_pregen_stor_func)
+                        @testset "MP w storage, $(case), $(backend), $(label), $(form_str)" begin
+                            test_callbacks(m32, m64, backend)
+                        end
                     end
                 end
             end
-            # Test DCOPF
+
+            # DCOPF
             for (filename, case, _) in test_cases
                 @testset "$case, DCOPF, $backend" begin
                     m32, _, _ = dcopf_model(filename; T=Float32, backend = backend)
-
-                    m64, v64, c64 = dcopf_model(filename; T=Float64, backend = backend)
-                    result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
-                    va64, pg64, pf64 = v64
-
-                    result_pm = get!(dcopf_ref_cache, filename) do
-                        nlp_solver = JuMP.optimizer_with_attributes(Ipopt.Optimizer, "tol"=>Float64(result64.options.tol), "print_level"=>0)
-                        solve_opf(filename, DCPPowerModel, nlp_solver)
-                    end
-
-                    test_dcopf_case(result64, result_pm, pg64, pf64)
+                    m64, _, _ = dcopf_model(filename; T=Float64, backend = backend)
+                    test_callbacks(m32, m64, backend)
                 end
             end
 
+            # User callbacks
             for T in (Float32, Float64)
                 @testset "User callback, $(T), $(backend)" begin
                     model, vars, cons = mpopf_model(
@@ -260,13 +234,8 @@ function runtests()
                         user_callback = add_electrolyzers, T=T, backend=backend)
                 end
             end
-
         end
 
-        # GOC3 is a max_iter=1 smoke test of the parser and the model constructor, and the
-        # two configurations together dominated the suite: on the CI runner (run
-        # 30814411004, 2h07m total) they cost 1h15m of the 2h04m spent in tests, building
-        # the same 139502-variable model twice.  Run it on the CPU only.
         if RUN_GOC3
             @testset "GOC3, Float64, nothing" begin
                 sc_tests("../data/C3E4N00073D1_scenario_303", nothing, Float64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,17 +2,28 @@ using Test, ExaModelsPower, MadNLP, MadNLPGPU, KernelAbstractions, CUDA, CUDSS, 
 
 include("opf_tests.jl")
 
-const CONFIGS = Any[
-    nothing,
-    CPU(),
-]
+# CI runs each backend, and the GOC3 smoke test, as a separate job, so the wall clock is
+# the slowest of them rather than their sum (they were 13.0, 14.8, 21.5 and 74.9 min in run
+# 30814411004).  EMP_TEST_SELECTION names the slice; it defaults to everything, so a plain
+# local `Pkg.test()` still runs the whole suite.
+const SELECTION = get(ENV, "EMP_TEST_SELECTION", "all")
+const VALID_SELECTIONS = ("all", "nothing", "cpu", "cuda", "goc3")
+SELECTION in VALID_SELECTIONS ||
+    error("EMP_TEST_SELECTION must be one of $(join(VALID_SELECTIONS, ", ")), got $(repr(SELECTION))")
 
-if CUDA.has_cuda_gpu()
-    push!(
-        CONFIGS,
-        CUDABackend(),
-    )
+# Asking for the GPU slice on a machine with no GPU must fail loudly: silently leaving
+# CONFIGS empty would make the job pass without running a single test.
+if SELECTION == "cuda" && !CUDA.has_cuda_gpu()
+    error("EMP_TEST_SELECTION=cuda but no CUDA device is visible")
 end
+
+const CONFIGS = Any[]
+SELECTION in ("all", "nothing") && push!(CONFIGS, nothing)
+SELECTION in ("all", "cpu") && push!(CONFIGS, CPU())
+SELECTION in ("all", "cuda") && CUDA.has_cuda_gpu() && push!(CONFIGS, CUDABackend())
+const RUN_GOC3 = SELECTION in ("all", "goc3")
+
+isempty(CONFIGS) && !RUN_GOC3 && error("EMP_TEST_SELECTION=$(SELECTION) selected no tests")
 
 test_cases = [("../data/pglib_opf_case3_lmbd.m", "case3", test_case3),
               ("../data/pglib_opf_case5_pjm.m", "case5", test_case5),
@@ -44,6 +55,8 @@ mp_stor_test_cases = [("../data/pglib_opf_case3_lmbd_mod.m", "case3", "../data/c
 
 static_forms = [("rect", :rect, ACRPowerModel, test_rect_voltage),
                 ("polar", :polar, ACPPowerModel, test_polar_voltage)]
+
+mp_forms = [("rect", :rect), ("polar", :polar)]
 
 function example_func(d, srating)
     return d + 20/srating*d^2
@@ -101,12 +114,18 @@ function runtests()
         static_ref_cache = Dict{Tuple{String,String},Any}()
         dcopf_ref_cache = Dict{String,Any}()
 
+        # The multi-period sections dominated the OPF phase (33.5 of its 49.4 min) and
+        # case3 and case5 exercise the same code with different data, so the multi-period
+        # sections keep case3 only.  Every backend otherwise runs the same set: with one
+        # job per backend the wall clock is the slowest backend, not their sum, so there
+        # is nothing to gain by giving them different coverage.
+        mp_cases = mp_test_cases[1:1]
+        mp_stor  = mp_stor_test_cases[1:1]
+
         for backend in CONFIGS
             for (filename, case, test_function) in test_cases
                 for (form_str, form, power_model, test_voltage) in static_forms
-                    m32, v32, c32 = ac_opf_model(filename; T=Float32, backend = backend, form=form)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    va32, vm32, pg32, qg32, p32, q32 = v32
+                    m32, _, _ = ac_opf_model(filename; T=Float32, backend = backend, form=form)
 
                     m64, v64, c64 = ac_opf_model(filename; T=Float64, backend = backend, form=form)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
@@ -123,32 +142,29 @@ function runtests()
                         (rpm, rnlp)
                     end
 
-                    @info form_str
                     @testset "$case, static, $backend, $form_str" begin
                         test_float32(m32, m64, result64, backend)
-                        eval(test_function)(result64, result_pm, result_nlp_pm, pg64, qg64, p64, q64)
+                        test_function(result64, result_pm, result_nlp_pm, pg64, qg64, p64, q64)
                         test_voltage(result64, result_pm, va64, vm64)
                     end
                 end
             end
             
             #Test MP
-            for (form_str, symbol) in [("rect", :rect), ("polar", :polar)]
-                for (filename, case, Pd_pregen, Qd_pregen, true_sol_curve, true_sol_pregen) in mp_test_cases
+            for (form_str, symbol) in mp_forms
+                for (filename, case, Pd_pregen, Qd_pregen, true_sol_curve, true_sol_pregen) in mp_cases
                     #Curve = [1, .9, .8, .95, 1]
 
-                    m32, v32, c32 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1]; T = Float32, backend = backend, form = symbol)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    m64, v64, c64 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1]; T = Float64, backend = backend, form = symbol)
+                    m32, _, _ = mpopf_model(filename, [1, .9, .8, .95, 1]; T = Float32, backend = backend, form = symbol)
+                    m64, v64, c64 = mpopf_model(filename, [1, .9, .8, .95, 1]; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     @testset "$(case), MP, $(backend), curve, $(form_str)" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_curve)
                     end
                     #w function
-                    m32, v32, c32 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1], example_func; T = Float32, backend = backend, form = symbol)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    m64, v64, c64 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1], example_func; T = Float64, backend = backend, form = symbol)
+                    m32, _, _ = mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = Float32, backend = backend, form = symbol)
+                    m64, v64, c64 = mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     @testset "$(case), MP, $(backend), curve, $(form_str), func" begin
                         test_float32(m32, m64, result64, backend)
@@ -157,18 +173,16 @@ function runtests()
                 
 
                     #Pregenerated Pd and Qd
-                    m32, v32, c32 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen; T = Float32, backend = backend, form = symbol)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    m64, v64, c64 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen; T = Float64, backend = backend, form = symbol)
+                    m32, _, _ = mpopf_model(filename, Pd_pregen, Qd_pregen; T = Float32, backend = backend, form = symbol)
+                    m64, v64, c64 = mpopf_model(filename, Pd_pregen, Qd_pregen; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     @testset "$(case), MP, $(backend), pregen, $(form_str)" begin
                         test_float32(m32, m64, result64, backend)
                         test_mp_case(result64, true_sol_pregen)
                     end
                     #w function
-                    m32, v32, c32 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen, example_func; T = Float32, backend = backend, form = symbol)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    m64, v64, c64 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen, example_func; T = Float64, backend = backend, form = symbol)
+                    m32, _, _ = mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = Float32, backend = backend, form = symbol)
+                    m64, v64, c64 = mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     @testset "$(case), MP, $(backend), pregen, $(form_str), func" begin
                         test_float32(m32, m64, result64, backend)
@@ -178,11 +192,10 @@ function runtests()
                 
                 # Test MP w storage
                 for (filename, case, Pd_pregen, Qd_pregen, true_sol_curve_stor, 
-                    true_sol_curve_stor_func, true_sol_pregen_stor, true_sol_pregen_stor_func) in mp_stor_test_cases
+                    true_sol_curve_stor_func, true_sol_pregen_stor, true_sol_pregen_stor_func) in mp_stor
                     
-                    m32, v32, c32 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1]; T = Float32, backend = backend, form = symbol)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    m64, v64, c64 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1]; T = Float64, backend = backend, form = symbol)
+                    m32, _, _ = mpopf_model(filename, [1, .9, .8, .95, 1]; T = Float32, backend = backend, form = symbol)
+                    m64, v64, c64 = mpopf_model(filename, [1, .9, .8, .95, 1]; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     @testset "MP w storage, $(case), $(backend), curve, $(form_str)" begin
                         test_float32(m32, m64, result64, backend)
@@ -190,9 +203,8 @@ function runtests()
                     end
 
                     #With function
-                    m32, v32, c32 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1], example_func; T = Float32, backend = backend, form = symbol)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    m64, v64, c64 = eval(mpopf_model)(filename, [1, .9, .8, .95, 1], example_func; T = Float64, backend = backend, form = symbol)
+                    m32, _, _ = mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = Float32, backend = backend, form = symbol)
+                    m64, v64, c64 = mpopf_model(filename, [1, .9, .8, .95, 1], example_func; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     @testset "MP w storage, $(case), $(backend), curve, $(form_str), func" begin
                         test_float32(m32, m64, result64, backend)
@@ -200,9 +212,8 @@ function runtests()
                     end
 
                     #Pregenerated Pd and Qd
-                    m32, v32, c32 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen; T = Float32, backend = backend, form = symbol)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    m64, v64, c64 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen; T = Float64, backend = backend, form = symbol)
+                    m32, _, _ = mpopf_model(filename, Pd_pregen, Qd_pregen; T = Float32, backend = backend, form = symbol)
+                    m64, v64, c64 = mpopf_model(filename, Pd_pregen, Qd_pregen; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     @testset "MP w storage, $(case), $(backend), pregen, $(form_str)" begin
                         test_float32(m32, m64, result64, backend)
@@ -210,9 +221,8 @@ function runtests()
                     end
 
                     #With function
-                    m32, v32, c32 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen, example_func; T = Float32, backend = backend, form = symbol)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
-                    m64, v64, c64 = eval(mpopf_model)(filename, Pd_pregen, Qd_pregen, example_func; T = Float64, backend = backend, form = symbol)
+                    m32, _, _ = mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = Float32, backend = backend, form = symbol)
+                    m64, v64, c64 = mpopf_model(filename, Pd_pregen, Qd_pregen, example_func; T = Float64, backend = backend, form = symbol)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
                     @testset "MP w storage, $(case), $(backend), pregen, $(form_str), func" begin
                         test_float32(m32, m64, result64, backend)
@@ -223,8 +233,7 @@ function runtests()
             # Test DCOPF
             for (filename, case, _) in test_cases
                 @testset "$case, DCOPF, $backend" begin
-                    m32, v32, c32 = dcopf_model(filename; T=Float32, backend = backend)
-                    result32 = exasolve(m32, backend; print_level = MadNLP.ERROR)
+                    m32, _, _ = dcopf_model(filename; T=Float32, backend = backend)
 
                     m64, v64, c64 = dcopf_model(filename; T=Float64, backend = backend)
                     result64 = exasolve(m64, backend; print_level = MadNLP.ERROR)
@@ -255,13 +264,13 @@ function runtests()
 
         end
 
-        goc3_configs = Tuple{DataType, Any}[(Float64, nothing)]
-        if CUDA.has_cuda_gpu()
-            push!(goc3_configs, (Float64, CUDABackend()))
-        end
-        for (T, backend) in goc3_configs
-            @testset "GOC3, $(T), $(backend)" begin
-                sc_tests("../data/C3E4N00073D1_scenario_303", backend, T)
+        # GOC3 is a max_iter=1 smoke test of the parser and the model constructor, and the
+        # two configurations together dominated the suite: on the CI runner (run
+        # 30814411004, 2h07m total) they cost 1h15m of the 2h04m spent in tests, building
+        # the same 139502-variable model twice.  Run it on the CPU only.
+        if RUN_GOC3
+            @testset "GOC3, Float64, nothing" begin
+                sc_tests("../data/C3E4N00073D1_scenario_303", nothing, Float64)
             end
         end
     end


### PR DESCRIPTION
CI took 2h07m per run. This brings it to **52m21s**, all jobs green.

| job | after | setup | tests | asserts |
|---|---|---|---|---|
| `nothing` | 21m04s | 0m34s | 19m22s | 472 |
| `cpu` | 33m23s | 11m44s | 20m01s | 450 |
| `cuda` | 37m01s | — | — | — |
| `goc3` | 52m15s | 0m33s | 50m13s | 2 |
| **run wall clock** | **52m21s** (from 2h07m) | | | |

Before the split there was a single job; the phase timeline reconstructed from run 30814411004's log was 3.2 min Pkg, 12.8 min static AC, 33.5 min MP + storage, 2.3 min DCOPF, 0.8 min user callbacks, 74.9 min GOC3.

### Run each backend, and GOC3, as its own job

They are independent, so the matrix runs four jobs and the wall clock is the slowest rather than the sum. `test/runtests.jl` selects its slice from `EMP_TEST_SELECTION`, defaulting to `all` so a local `Pkg.test()` is unchanged. Requesting the `cuda` slice with no visible device raises rather than leaving the backend list empty and passing a job that ran no tests.

### Check callbacks instead of solving

Solving dominated the run, and MadNLP is not what this package is responsible for — its job is to build correct models. Every configuration is now checked by evaluating objective, constraints, gradient and Jacobian at the model's initial point and at two perturbations, asserting they are finite and that the Float32 model tracks the Float64 one.

Two solves are kept, both on case3, once on the CPU and once on the GPU: static AC against the PowerModels/Ipopt reference, and multi-period against the hardcoded objective — the latter being the only check on `mpopf` answers. GOC3 builds and evaluates its model but never solves, which took that job from 1h37m to 52m.

The evaluation point moved from a solution to `meta.x0`, a far worse conditioned place to evaluate an OPF. Checked first on eight configurations locally — both formulations, static, multi-period, storage, storage with a discharge function, DCOPF, case14 — all finite and matching between precisions.

### Drop redundant work

- The Float32 solves. `result32` was assigned in ten places and never read.
- The CUDA GOC3 configuration. Both configurations built the same 139502-variable model for a `max_iter=1` smoke test.
- case5 in the multi-period sections, which exercises the same code as case3 with different data.
- The `@info` dumps of the full PowerModels solution dictionary, most of a 280 KB job log.

### Cancel superseded pull-request runs

Both workflows now use a concurrency group; two full runs of the same branch had been in flight simultaneously against a shared self-hosted pool. Runs on `main` are exempt so every merged commit still reports coverage.

### Where the time goes now

These models are small — the largest is n=290 — and once a shape is compiled a solve takes under 0.05 s. Locally, an already-compiled configuration and a first-of-its-kind configuration of identical size differ by three orders of magnitude (0.00 s vs 22.3 s). The suite is compile-bound and the unit of cost is the distinct model shape: the backend jobs average about 21 s per model build. GOC3 is now entirely construction — its log shows the JSON parsed at +2m45 and `built model` at +39m33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
